### PR TITLE
Some result additions

### DIFF
--- a/Results.Tests/DotNetThoughts.Results.Tests.csproj
+++ b/Results.Tests/DotNetThoughts.Results.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Results.Tests/DotNetThoughts.Results.Tests.csproj
+++ b/Results.Tests/DotNetThoughts.Results.Tests.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="xunit.core" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.core" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Results/BindAll.cs
+++ b/Results/BindAll.cs
@@ -23,6 +23,27 @@ public static partial class Extensions
         }
     }
 
+    public static Result<Unit> BindAll<T>(this Result<IEnumerable<T>> source, Func<T, int, Result<Unit>> next)
+    {
+        if (source.Success)
+        {
+            var results = new List<Result<Unit>>();
+            var index = 0;
+            foreach (var s in source.Value)
+            {
+                results.Add(next(s, index));
+                index++;
+            }
+            return results.Any(x => !x.Success)
+                ? UnitResult.Error(results.SelectMany(x => x.Errors))
+                : UnitResult.Ok;
+        }
+        else
+        {
+            return Result<Unit>.Error(source.Errors);
+        }
+    }
+
     public static async Task<Result<Unit>> BindAll<T>(this Result<IEnumerable<T>> source, Func<T, Task<Result<Unit>>> next)
     {
         if (source.Success)
@@ -31,6 +52,27 @@ public static partial class Extensions
             foreach (var s in source.Value)
             {
                 results.Add(await next(s));
+            }
+            return results.Any(x => !x.Success)
+                ? UnitResult.Error(results.SelectMany(x => x.Errors))
+                : UnitResult.Ok;
+        }
+        else
+        {
+            return Result<Unit>.Error(source.Errors);
+        }
+    }
+
+    public static async Task<Result<Unit>> BindAll<T>(this Result<IEnumerable<T>> source, Func<T, int, Task<Result<Unit>>> next)
+    {
+        if (source.Success)
+        {
+            var results = new List<Result<Unit>>();
+            var index = 0;
+            foreach (var s in source.Value)
+            {
+                results.Add(await next(s, index));
+                index++;
             }
             return results.Any(x => !x.Success)
                 ? UnitResult.Error(results.SelectMany(x => x.Errors))
@@ -65,35 +107,117 @@ public static partial class Extensions
         }
     }
 
-    [Obsolete("Does not take a Result as input. Use one of the regular extensions that takes a result as input. (Do a .Return() on your non-result object first)")]
-    public static Result<List<TResult>> BindAll<T, TResult>(this IEnumerable<T> source, Func<T, Result<TResult>> next)
+    public static Result<List<TResult>> BindAll<T, TResult>(this Result<IEnumerable<T>> source, Func<T, int, Result<TResult>> next)
     {
-        var results = new List<Result<TResult>>();
-
-        foreach (var s in source)
+        if (source.Success)
         {
-            results.Add(next(s));
+            var results = new List<Result<TResult>>();
+            var index = 0;
+            foreach (var s in source.Value)
+            {
+                results.Add(next(s, index));
+                index++;
+            }
+            return results.Any(x => !x.Success)
+               ? Result<List<TResult>>.Error(results.SelectMany(x => x.Errors))
+               : Result<List<TResult>>.Ok(results.Select(x => x.Value).ToList());
         }
-        return results.Any(x => !x.Success)
-            ? Result<List<TResult>>.Error(results.SelectMany(x => x.Errors))
-            : Result<List<TResult>>.Ok(results.Select(x => x.Value).ToList());
+        else
+        {
+            return Result<List<TResult>>.Error(source.Errors);
+        }
     }
 
-    [Obsolete("Does not take a Result as input. Use one of the regular extensions that takes a result as input. (Do a .Return() on your non-result object first)")]
-    public static async Task<Result<List<TResult>>> BindAll<T, TResult>(this IEnumerable<T> source, Func<T, Task<Result<TResult>>> next)
+    /// <summary>
+    /// Does not short circuit. Returns all errors or all results
+    /// </summary>
+    public static async Task<Result<List<TResult>>> BindAll<T, TResult>(this Result<IEnumerable<T>> source, Func<T, Task<Result<TResult>>> next)
     {
-        var results = new List<Result<TResult>>();
-
-        foreach (var s in source)
+        if (source.Success)
         {
-            results.Add(await next(s));
+            var results = new List<Result<TResult>>();
+
+            foreach (var s in source.Value)
+            {
+                results.Add(await next(s));
+            }
+            return results.Any(x => !x.Success)
+               ? Result<List<TResult>>.Error(results.SelectMany(x => x.Errors))
+               : Result<List<TResult>>.Ok(results.Select(x => x.Value).ToList());
         }
-        return results.Any(x => !x.Success)
-            ? Result<List<TResult>>.Error(results.SelectMany(x => x.Errors))
-            : Result<List<TResult>>.Ok(results.Select(x => x.Value).ToList());
+        else
+        {
+            return Result<List<TResult>>.Error(source.Errors);
+        }
     }
 
-    // with tasks
+    public static async Task<Result<List<TResult>>> BindAll<T, TResult>(this Result<IEnumerable<T>> source, Func<T, int, Task<Result<TResult>>> next)
+    {
+        if (source.Success)
+        {
+            var results = new List<Result<TResult>>();
+            var index = 0;
+            foreach (var s in source.Value)
+            {
+                results.Add(await next(s, index));
+                index++;
+            }
+            return results.Any(x => !x.Success)
+               ? Result<List<TResult>>.Error(results.SelectMany(x => x.Errors))
+               : Result<List<TResult>>.Ok(results.Select(x => x.Value).ToList());
+        }
+        else
+        {
+            return Result<List<TResult>>.Error(source.Errors);
+        }
+    }
+
+    ////// Same as above, but from tasks
+
+
+    /// <summary>
+    /// Does not short circuit. Returns all errors or one unit
+    /// </summary>
+    public static async Task<Result<Unit>> BindAll<T>(this Task<Result<IEnumerable<T>>> source, Func<T, Result<Unit>> next)
+    {
+        if ((await source).Success)
+        {
+            var results = new List<Result<Unit>>();
+            foreach (var s in (await source).Value)
+            {
+                results.Add(next(s));
+            }
+            return results.Any(x => !x.Success)
+                ? UnitResult.Error(results.SelectMany(x => x.Errors))
+                : UnitResult.Ok;
+        }
+        else
+        {
+            return Result<Unit>.Error((await source).Errors);
+        }
+    }
+
+    public static async Task<Result<Unit>> BindAll<T>(this Task<Result<IEnumerable<T>>> source, Func<T, int, Result<Unit>> next)
+    {
+        if ((await source).Success)
+        {
+            var results = new List<Result<Unit>>();
+            var index = 0;
+            foreach (var s in (await source).Value)
+            {
+                results.Add(next(s, index));
+                index++;
+            }
+            return results.Any(x => !x.Success)
+                ? UnitResult.Error(results.SelectMany(x => x.Errors))
+                : UnitResult.Ok;
+        }
+        else
+        {
+            return Result<Unit>.Error((await source).Errors);
+        }
+    }
+
     public static async Task<Result<Unit>> BindAll<T>(this Task<Result<IEnumerable<T>>> source, Func<T, Task<Result<Unit>>> next)
     {
         if ((await source).Success)
@@ -102,6 +226,27 @@ public static partial class Extensions
             foreach (var s in (await source).Value)
             {
                 results.Add(await next(s));
+            }
+            return results.Any(x => !x.Success)
+                ? UnitResult.Error(results.SelectMany(x => x.Errors))
+                : UnitResult.Ok;
+        }
+        else
+        {
+            return Result<Unit>.Error((await source).Errors);
+        }
+    }
+
+    public static async Task<Result<Unit>> BindAll<T>(this Task<Result<IEnumerable<T>>> source, Func<T, int, Task<Result<Unit>>> next)
+    {
+        if ((await source).Success)
+        {
+            var results = new List<Result<Unit>>();
+            var index = 0;
+            foreach (var s in (await source).Value)
+            {
+                results.Add(await next(s, index));
+                index++;
             }
             return results.Any(x => !x.Success)
                 ? UnitResult.Error(results.SelectMany(x => x.Errors))
@@ -136,6 +281,30 @@ public static partial class Extensions
         }
     }
 
+    public static async Task<Result<List<TResult>>> BindAll<T, TResult>(this Task<Result<IEnumerable<T>>> source, Func<T, int, Result<TResult>> next)
+    {
+        if ((await source).Success)
+        {
+            var results = new List<Result<TResult>>();
+            var index = 0;
+            foreach (var s in (await source).Value)
+            {
+                results.Add(next(s, index));
+                index++;
+            }
+            return results.Any(x => !x.Success)
+               ? Result<List<TResult>>.Error(results.SelectMany(x => x.Errors))
+               : Result<List<TResult>>.Ok(results.Select(x => x.Value).ToList());
+        }
+        else
+        {
+            return Result<List<TResult>>.Error((await source).Errors);
+        }
+    }
+
+    /// <summary>
+    /// Does not short circuit. Returns all errors or all results
+    /// </summary>
     public static async Task<Result<List<TResult>>> BindAll<T, TResult>(this Task<Result<IEnumerable<T>>> source, Func<T, Task<Result<TResult>>> next)
     {
         if ((await source).Success)
@@ -145,6 +314,27 @@ public static partial class Extensions
             foreach (var s in (await source).Value)
             {
                 results.Add(await next(s));
+            }
+            return results.Any(x => !x.Success)
+               ? Result<List<TResult>>.Error(results.SelectMany(x => x.Errors))
+               : Result<List<TResult>>.Ok(results.Select(x => x.Value).ToList());
+        }
+        else
+        {
+            return Result<List<TResult>>.Error((await source).Errors);
+        }
+    }
+
+    public static async Task<Result<List<TResult>>> BindAll<T, TResult>(this Task<Result<IEnumerable<T>>> source, Func<T, int, Task<Result<TResult>>> next)
+    {
+        if ((await source).Success)
+        {
+            var results = new List<Result<TResult>>();
+            var index = 0;
+            foreach (var s in (await source).Value)
+            {
+                results.Add(await next(s, index));
+                index++;
             }
             return results.Any(x => !x.Success)
                ? Result<List<TResult>>.Error(results.SelectMany(x => x.Errors))

--- a/Results/BindEach.cs
+++ b/Results/BindEach.cs
@@ -4,50 +4,6 @@ public static partial class Extensions
     /// <summary>
     /// Short circuits on failure
     /// </summary>
-    [Obsolete("Does not take a Result as input. Use one of the regular extensions that takes a result as input. (Do a .Return() on your non-result object first)")]
-    public static Result<Unit> BindEach<T>(this IEnumerable<T> source, Func<T, Result<Unit>> next)
-    {
-        foreach (var s in source)
-        {
-            var result = next(s);
-            if (!result.Success) return result;
-        }
-        return UnitResult.Ok;
-    }
-
-    /// <summary>
-    /// Short circuits on failure
-    /// </summary>
-    [Obsolete("Does not take a Result as input. Use one of the regular extensions that takes a result as input. (Do a .Return() on your non-result object first)")]
-    public static async Task<Result<Unit>> BindEach<T>(this IEnumerable<T> source, Func<T, Task<Result<Unit>>> next)
-    {
-        foreach (var s in source)
-        {
-            var result = await next(s);
-            if (!result.Success) return result;
-        }
-        return UnitResult.Ok;
-    }
-
-    /// <summary>
-    /// Short circuits on failure
-    /// </summary>
-    [Obsolete("Does not take a Result as input. Use one of the regular extensions that takes a result as input. (Do a .Return() on your non-result object first)")]
-    public static Result<List<TResult>> BindEach<T, TResult>(this IEnumerable<T> source, Func<T, Result<TResult>> next)
-    {
-        var result = new List<TResult>();
-        foreach (var s in source)
-        {
-            var r = next(s);
-            if (!r.Success) return Result<List<TResult>>.Error(r.Errors);
-            result.Add(r.Value);
-        }
-        return Result<List<TResult>>.Ok(result);
-    }
-
-    /// <summary>
-    /// Short circuits on failure
-    /// </summary>
     public static Result<Unit> BindEach<T>(this Result<IEnumerable<T>> source, Func<T, Result<Unit>> next)
     {
         if (source.Success)

--- a/Results/DotNetThoughts.Results.csproj
+++ b/Results/DotNetThoughts.Results.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<Version>1.4.3</Version>
+		<Version>1.5.0</Version>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>

--- a/Results/ErrorBase.cs
+++ b/Results/ErrorBase.cs
@@ -57,7 +57,7 @@ public abstract record ErrorBase : IError
     public Dictionary<string, object?> Data { get => GetData(); }
 
     [Pure]
-    private Dictionary<string, object?> GetData()
+    public Dictionary<string, object?> GetData()
     {
         var propValues = GetType()
          .GetProperties()

--- a/Results/ErrorBase.cs
+++ b/Results/ErrorBase.cs
@@ -47,13 +47,26 @@ public abstract record ErrorBase : IError
     /// </summary>
     public string Message { get; protected set; }
 
+    private Dictionary<string, object?> _data = [];
+
     /// <summary>
-    /// Scans the inheriting type for all properties and returns them as a dictionary where property name is key, and the property value is the value.
+    /// In addition to data you add yourself, this also contains all properties on the inheriting type with property name as key and property value as value.
+    /// If you add a key to this dictionary, where the inheriting type has a property with the same name as your key, the value of that dictionary entry will be overwritten by the value of the property.
     /// </summary>
     /// <returns></returns>
+    public Dictionary<string, object?> Data { get => GetData(); }
+
     [Pure]
-    public Dictionary<string, object?> GetData() => GetType()
+    private Dictionary<string, object?> GetData()
+    {
+        var propValues = GetType()
          .GetProperties()
          .Where(p => p.DeclaringType != typeof(IError) && p.DeclaringType != typeof(ErrorBase))
          .ToDictionary(d => d.Name, d => d.GetValue(this));
+        foreach (var prop in propValues)
+        {
+            _data[prop.Key] = prop.Value;
+        }
+        return _data;
+    }
 }

--- a/Results/Or.cs
+++ b/Results/Or.cs
@@ -8,68 +8,65 @@
 /// </summary>
 public static partial class Extensions
 {
-        public static Result<(T, T2)> OrResult<T, T2>(Result<T> a, Result<T2> b) => a.Or(b);
-        public static Result<(T, T2, T3)> OrResult<T, T2, T3>(Result<T> a, Result<T2> b, Result<T3> c) => a.Or(b).Or(c);
-        public static Result<(T, T2, T3, T4)> OrResult<T, T2, T3, T4>(Result<T> a, Result<T2> b, Result<T3> c, Result<T4> d) => a.Or(b).Or(c).Or(d);
-        public static Result<(T, T2, T3, T4, T5)> OrResult<T, T2, T3, T4, T5>(Result<T> a, Result<T2> b, Result<T3> c, Result<T4> d, Result<T5> e) => a.Or(b).Or(c).Or(d).Or(e);
-        public static Result<(T, T2, T3, T4, T5, T6)> OrResult<T, T2, T3, T4, T5, T6>(Result<T> a, Result<T2> b, Result<T3> c, Result<T4> d, Result<T5> e, Result<T6> f) => a.Or(b).Or(c).Or(d).Or(e).Or(f);
-        public static Result<(T, T2, T3, T4, T5, T6, T7)> OrResult<T, T2, T3, T4, T5, T6, T7>(Result<T> a, Result<T2> b, Result<T3> c, Result<T4> d, Result<T5> e, Result<T6> f, Result<T7> g) => a.Or(b).Or(c).Or(d).Or(e).Or(f).Or(g);
-        public static Result<(T, T2, T3, T4, T5, T6, T7, T8)> OrResult<T, T2, T3, T4, T5, T6, T7, T8>(Result<T> a, Result<T2> b, Result<T3> c, Result<T4> d, Result<T5> e, Result<T6> f, Result<T7> g, Result<T8> h) => a.Or(b).Or(c).Or(d).Or(e).Or(f).Or(g).Or(h);
-        public static Result<(T, T2, T3, T4, T5, T6, T7, T8, T9)> OrResult<T, T2, T3, T4, T5, T6, T7, T8, T9>(Result<T> a, Result<T2> b, Result<T3> c, Result<T4> d, Result<T5> e, Result<T6> f, Result<T7> g, Result<T8> h, Result<T9> i) => a.Or(b).Or(c).Or(d).Or(e).Or(f).Or(g).Or(h).Or(i);
-        public static Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10)> OrResult<T, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Result<T> a, Result<T2> b, Result<T3> c, Result<T4> d, Result<T5> e, Result<T6> f, Result<T7> g, Result<T8> h, Result<T9> i, Result<T10> j) => a.Or(b).Or(c).Or(d).Or(e).Or(f).Or(g).Or(h).Or(i).Or(j);
-        public static Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)> OrResult<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Result<T> a, Result<T2> b, Result<T3> c, Result<T4> d, Result<T5> e, Result<T6> f, Result<T7> g, Result<T8> h, Result<T9> i, Result<T10> j, Result<T11> k) => a.Or(b).Or(c).Or(d).Or(e).Or(f).Or(g).Or(h).Or(i).Or(j).Or(k);
-        public static Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)> OrResult<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Result<T> a, Result<T2> b, Result<T3> c, Result<T4> d, Result<T5> e, Result<T6> f, Result<T7> g, Result<T8> h, Result<T9> i, Result<T10> j, Result<T11> k, Result<T12> l) => a.Or(b).Or(c).Or(d).Or(e).Or(f).Or(g).Or(h).Or(i).Or(j).Or(k).Or(l);
-
-        public static Result<(T, T2)> Or<T, T2>(this Result<T> a, Result<T2> b) => !a.Success || !b.Success
-                ? Result<(T, T2)>.Error(a.Errors.Concat(b.Errors))
-                : Result<(T, T2)>.Ok((a.Value, b.Value));
-        public static async Task<Result<(T, T2)>> Or<T, T2>(this Task<Result<T>> a, Result<T2> b) => !(await a).Success || !b.Success
-               ? Result<(T, T2)>.Error((await a).Errors.Concat(b.Errors))
-               : Result<(T, T2)>.Ok(((await a).Value, b.Value));
-        public static async Task<Result<(T, T2)>> Or<T, T2>(this Task<Result<T>> a, Task<Result<T2>> b) => !(await a).Success || !(await b).Success
-                 ? Result<(T, T2)>.Error((await a).Errors.Concat((await b).Errors))
-                 : Result<(T, T2)>.Ok(((await a).Value, (await b).Value));
-
-        public static Result<(T, T2, T3)> Or<T, T2, T3>(this Result<(T, T2)> a, Result<T3> b) => !a.Success || !b.Success
-                ? Result<(T, T2, T3)>.Error(a.Errors.Concat(b.Errors))
-                : Result<(T, T2, T3)>.Ok((a.Value.Item1, a.Value.Item2, b.Value));
-        public static async Task<Result<(T, T2, T3)>> Or<T, T2, T3>(this Task<Result<(T, T2)>> a, Task<Result<T3>> b) => !(await a).Success || !(await b).Success
-            ? Result<(T, T2, T3)>.Error((await a).Errors.Concat((await b).Errors))
-            : Result<(T, T2, T3)>.Ok(((await a).Value.Item1, (await a).Value.Item2, (await b).Value));
-
-        public static Result<(T, T2, T3, T4)> Or<T, T2, T3, T4>(this Result<(T, T2, T3)> a, Result<T4> b) => !a.Success || !b.Success
-                ? Result<(T, T2, T3, T4)>.Error(a.Errors.Concat(b.Errors))
-                : Result<(T, T2, T3, T4)>.Ok((a.Value.Item1, a.Value.Item2, a.Value.Item3, b.Value));
-
-        public static Result<(T, T2, T3, T4, T5)> Or<T, T2, T3, T4, T5>(this Result<(T, T2, T3, T4)> a, Result<T5> b) => !a.Success || !b.Success
-                ? Result<(T, T2, T3, T4, T5)>.Error(a.Errors.Concat(b.Errors))
-                : Result<(T, T2, T3, T4, T5)>.Ok((a.Value.Item1, a.Value.Item2, a.Value.Item3, a.Value.Item4, b.Value));
-
-        public static Result<(T, T2, T3, T4, T5, T6)> Or<T, T2, T3, T4, T5, T6>(this Result<(T, T2, T3, T4, T5)> a, Result<T6> b) => !a.Success || !b.Success
-                ? Result<(T, T2, T3, T4, T5, T6)>.Error(a.Errors.Concat(b.Errors))
-                : Result<(T, T2, T3, T4, T5, T6)>.Ok((a.Value.Item1, a.Value.Item2, a.Value.Item3, a.Value.Item4, a.Value.Item5, b.Value));
-
-        public static Result<(T, T2, T3, T4, T5, T6, T7)> Or<T, T2, T3, T4, T5, T6, T7>(this Result<(T, T2, T3, T4, T5, T6)> a, Result<T7> b) => !a.Success || !b.Success
-                ? Result<(T, T2, T3, T4, T5, T6, T7)>.Error(a.Errors.Concat(b.Errors))
-                : Result<(T, T2, T3, T4, T5, T6, T7)>.Ok((a.Value.Item1, a.Value.Item2, a.Value.Item3, a.Value.Item4, a.Value.Item5, a.Value.Item6, b.Value));
-
-        public static Result<(T, T2, T3, T4, T5, T6, T7, T8)> Or<T, T2, T3, T4, T5, T6, T7, T8>(this Result<(T, T2, T3, T4, T5, T6, T7)> a, Result<T8> b) => !a.Success || !b.Success
-                ? Result<(T, T2, T3, T4, T5, T6, T7, T8)>.Error(a.Errors.Concat(b.Errors))
-                : Result<(T, T2, T3, T4, T5, T6, T7, T8)>.Ok((a.Value.Item1, a.Value.Item2, a.Value.Item3, a.Value.Item4, a.Value.Item5, a.Value.Item6, a.Value.Item7, b.Value));
-
-        public static Result<(T, T2, T3, T4, T5, T6, T7, T8, T9)> Or<T, T2, T3, T4, T5, T6, T7, T8, T9>(this Result<(T, T2, T3, T4, T5, T6, T7, T8)> a, Result<T9> b) => !a.Success || !b.Success
-                ? Result<(T, T2, T3, T4, T5, T6, T7, T8, T9)>.Error(a.Errors.Concat(b.Errors))
-                : Result<(T, T2, T3, T4, T5, T6, T7, T8, T9)>.Ok((a.Value.Item1, a.Value.Item2, a.Value.Item3, a.Value.Item4, a.Value.Item5, a.Value.Item6, a.Value.Item7, a.Value.Item8, b.Value));
-
-        public static Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10)> Or<T, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this Result<(T, T2, T3, T4, T5, T6, T7, T8, T9)> a, Result<T10> b) => !a.Success || !b.Success
-            ? Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10)>.Error(a.Errors.Concat(b.Errors))
-            : Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10)>.Ok((a.Value.Item1, a.Value.Item2, a.Value.Item3, a.Value.Item4, a.Value.Item5, a.Value.Item6, a.Value.Item7, a.Value.Item8, a.Value.Item9, b.Value));
-
-        public static Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)> Or<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10)> a, Result<T11> b) => !a.Success || !b.Success
-            ? Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)>.Error(a.Errors.Concat(b.Errors))
-            : Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)>.Ok((a.Value.Item1, a.Value.Item2, a.Value.Item3, a.Value.Item4, a.Value.Item5, a.Value.Item6, a.Value.Item7, a.Value.Item8, a.Value.Item9, a.Value.Item10, b.Value));
-
-        public static Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)> Or<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)> a, Result<T12> b) => !a.Success || !b.Success
-            ? Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)>.Error(a.Errors.Concat(b.Errors))
-            : Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)>.Ok((a.Value.Item1, a.Value.Item2, a.Value.Item3, a.Value.Item4, a.Value.Item5, a.Value.Item6, a.Value.Item7, a.Value.Item8, a.Value.Item9, a.Value.Item10, a.Value.Item11, b.Value));
+    public static Result<(T, T2)> OrResult<T, T2>(Result<T> a, Result<T2> b) => a.Or(b);
+    public static Result<(T, T2, T3)> OrResult<T, T2, T3>(Result<T> a, Result<T2> b, Result<T3> c) => a.Or(b).Or(c);
+    public static Result<(T, T2, T3, T4)> OrResult<T, T2, T3, T4>(Result<T> a, Result<T2> b, Result<T3> c, Result<T4> d) => a.Or(b).Or(c).Or(d);
+    public static Result<(T, T2, T3, T4, T5)> OrResult<T, T2, T3, T4, T5>(Result<T> a, Result<T2> b, Result<T3> c, Result<T4> d, Result<T5> e) => a.Or(b).Or(c).Or(d).Or(e);
+    public static Result<(T, T2, T3, T4, T5, T6)> OrResult<T, T2, T3, T4, T5, T6>(Result<T> a, Result<T2> b, Result<T3> c, Result<T4> d, Result<T5> e, Result<T6> f) => a.Or(b).Or(c).Or(d).Or(e).Or(f);
+    public static Result<(T, T2, T3, T4, T5, T6, T7)> OrResult<T, T2, T3, T4, T5, T6, T7>(Result<T> a, Result<T2> b, Result<T3> c, Result<T4> d, Result<T5> e, Result<T6> f, Result<T7> g) => a.Or(b).Or(c).Or(d).Or(e).Or(f).Or(g);
+    public static Result<(T, T2, T3, T4, T5, T6, T7, T8)> OrResult<T, T2, T3, T4, T5, T6, T7, T8>(Result<T> a, Result<T2> b, Result<T3> c, Result<T4> d, Result<T5> e, Result<T6> f, Result<T7> g, Result<T8> h) => a.Or(b).Or(c).Or(d).Or(e).Or(f).Or(g).Or(h);
+    public static Result<(T, T2, T3, T4, T5, T6, T7, T8, T9)> OrResult<T, T2, T3, T4, T5, T6, T7, T8, T9>(Result<T> a, Result<T2> b, Result<T3> c, Result<T4> d, Result<T5> e, Result<T6> f, Result<T7> g, Result<T8> h, Result<T9> i) => a.Or(b).Or(c).Or(d).Or(e).Or(f).Or(g).Or(h).Or(i);
+    public static Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10)> OrResult<T, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Result<T> a, Result<T2> b, Result<T3> c, Result<T4> d, Result<T5> e, Result<T6> f, Result<T7> g, Result<T8> h, Result<T9> i, Result<T10> j) => a.Or(b).Or(c).Or(d).Or(e).Or(f).Or(g).Or(h).Or(i).Or(j);
+    public static Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)> OrResult<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Result<T> a, Result<T2> b, Result<T3> c, Result<T4> d, Result<T5> e, Result<T6> f, Result<T7> g, Result<T8> h, Result<T9> i, Result<T10> j, Result<T11> k) => a.Or(b).Or(c).Or(d).Or(e).Or(f).Or(g).Or(h).Or(i).Or(j).Or(k);
+    public static Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)> OrResult<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Result<T> a, Result<T2> b, Result<T3> c, Result<T4> d, Result<T5> e, Result<T6> f, Result<T7> g, Result<T8> h, Result<T9> i, Result<T10> j, Result<T11> k, Result<T12> l) => a.Or(b).Or(c).Or(d).Or(e).Or(f).Or(g).Or(h).Or(i).Or(j).Or(k).Or(l);
+    public static Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)> Or<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(Result<T> a, Result<T2> b, Result<T3> c, Result<T4> d, Result<T5> e, Result<T6> f, Result<T7> g, Result<T8> h, Result<T9> i, Result<T10> j, Result<T11> k, Result<T12> l, Result<T13> m) => a.Or(b).Or(c).Or(d).Or(e).Or(f).Or(g).Or(h).Or(i).Or(j).Or(k).Or(l).Or(m);
+    public static Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)> Or<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(Result<T> a, Result<T2> b, Result<T3> c, Result<T4> d, Result<T5> e, Result<T6> f, Result<T7> g, Result<T8> h, Result<T9> i, Result<T10> j, Result<T11> k, Result<T12> l, Result<T13> m, Result<T14> n) => a.Or(b).Or(c).Or(d).Or(e).Or(f).Or(g).Or(h).Or(i).Or(j).Or(k).Or(l).Or(m).Or(n);
+    public static Result<(T, T2)> Or<T, T2>(this Result<T> a, Result<T2> b) => !a.Success || !b.Success
+        ? Result<(T, T2)>.Error(a.Errors.Concat(b.Errors))
+        : Result<(T, T2)>.Ok((a.Value, b.Value));
+    public static async Task<Result<(T, T2)>> Or<T, T2>(this Task<Result<T>> a, Result<T2> b) => !(await a).Success || !b.Success
+        ? Result<(T, T2)>.Error((await a).Errors.Concat(b.Errors))
+        : Result<(T, T2)>.Ok(((await a).Value, b.Value));
+    public static async Task<Result<(T, T2)>> Or<T, T2>(this Task<Result<T>> a, Task<Result<T2>> b) => !(await a).Success || !(await b).Success
+        ? Result<(T, T2)>.Error((await a).Errors.Concat((await b).Errors))
+        : Result<(T, T2)>.Ok(((await a).Value, (await b).Value));
+    public static Result<(T, T2, T3)> Or<T, T2, T3>(this Result<(T, T2)> a, Result<T3> b) => !a.Success || !b.Success
+        ? Result<(T, T2, T3)>.Error(a.Errors.Concat(b.Errors))
+        : Result<(T, T2, T3)>.Ok((a.Value.Item1, a.Value.Item2, b.Value));
+    public static async Task<Result<(T, T2, T3)>> Or<T, T2, T3>(this Task<Result<(T, T2)>> a, Task<Result<T3>> b) => !(await a).Success || !(await b).Success
+        ? Result<(T, T2, T3)>.Error((await a).Errors.Concat((await b).Errors))
+        : Result<(T, T2, T3)>.Ok(((await a).Value.Item1, (await a).Value.Item2, (await b).Value));
+    public static Result<(T, T2, T3, T4)> Or<T, T2, T3, T4>(this Result<(T, T2, T3)> a, Result<T4> b) => !a.Success || !b.Success
+        ? Result<(T, T2, T3, T4)>.Error(a.Errors.Concat(b.Errors))
+        : Result<(T, T2, T3, T4)>.Ok((a.Value.Item1, a.Value.Item2, a.Value.Item3, b.Value));
+    public static Result<(T, T2, T3, T4, T5)> Or<T, T2, T3, T4, T5>(this Result<(T, T2, T3, T4)> a, Result<T5> b) => !a.Success || !b.Success
+        ? Result<(T, T2, T3, T4, T5)>.Error(a.Errors.Concat(b.Errors))
+        : Result<(T, T2, T3, T4, T5)>.Ok((a.Value.Item1, a.Value.Item2, a.Value.Item3, a.Value.Item4, b.Value));
+    public static Result<(T, T2, T3, T4, T5, T6)> Or<T, T2, T3, T4, T5, T6>(this Result<(T, T2, T3, T4, T5)> a, Result<T6> b) => !a.Success || !b.Success
+        ? Result<(T, T2, T3, T4, T5, T6)>.Error(a.Errors.Concat(b.Errors))
+        : Result<(T, T2, T3, T4, T5, T6)>.Ok((a.Value.Item1, a.Value.Item2, a.Value.Item3, a.Value.Item4, a.Value.Item5, b.Value));
+    public static Result<(T, T2, T3, T4, T5, T6, T7)> Or<T, T2, T3, T4, T5, T6, T7>(this Result<(T, T2, T3, T4, T5, T6)> a, Result<T7> b) => !a.Success || !b.Success
+        ? Result<(T, T2, T3, T4, T5, T6, T7)>.Error(a.Errors.Concat(b.Errors))
+        : Result<(T, T2, T3, T4, T5, T6, T7)>.Ok((a.Value.Item1, a.Value.Item2, a.Value.Item3, a.Value.Item4, a.Value.Item5, a.Value.Item6, b.Value));
+    public static Result<(T, T2, T3, T4, T5, T6, T7, T8)> Or<T, T2, T3, T4, T5, T6, T7, T8>(this Result<(T, T2, T3, T4, T5, T6, T7)> a, Result<T8> b) => !a.Success || !b.Success
+        ? Result<(T, T2, T3, T4, T5, T6, T7, T8)>.Error(a.Errors.Concat(b.Errors))
+        : Result<(T, T2, T3, T4, T5, T6, T7, T8)>.Ok((a.Value.Item1, a.Value.Item2, a.Value.Item3, a.Value.Item4, a.Value.Item5, a.Value.Item6, a.Value.Item7, b.Value));
+    public static Result<(T, T2, T3, T4, T5, T6, T7, T8, T9)> Or<T, T2, T3, T4, T5, T6, T7, T8, T9>(this Result<(T, T2, T3, T4, T5, T6, T7, T8)> a, Result<T9> b) => !a.Success || !b.Success
+        ? Result<(T, T2, T3, T4, T5, T6, T7, T8, T9)>.Error(a.Errors.Concat(b.Errors))
+        : Result<(T, T2, T3, T4, T5, T6, T7, T8, T9)>.Ok((a.Value.Item1, a.Value.Item2, a.Value.Item3, a.Value.Item4, a.Value.Item5, a.Value.Item6, a.Value.Item7, a.Value.Item8, b.Value));
+    public static Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10)> Or<T, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this Result<(T, T2, T3, T4, T5, T6, T7, T8, T9)> a, Result<T10> b) => !a.Success || !b.Success
+        ? Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10)>.Error(a.Errors.Concat(b.Errors))
+        : Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10)>.Ok((a.Value.Item1, a.Value.Item2, a.Value.Item3, a.Value.Item4, a.Value.Item5, a.Value.Item6, a.Value.Item7, a.Value.Item8, a.Value.Item9, b.Value));
+    public static Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)> Or<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10)> a, Result<T11> b) => !a.Success || !b.Success
+        ? Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)>.Error(a.Errors.Concat(b.Errors))
+        : Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)>.Ok((a.Value.Item1, a.Value.Item2, a.Value.Item3, a.Value.Item4, a.Value.Item5, a.Value.Item6, a.Value.Item7, a.Value.Item8, a.Value.Item9, a.Value.Item10, b.Value));
+    public static Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)> Or<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)> a, Result<T12> b) => !a.Success || !b.Success
+        ? Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)>.Error(a.Errors.Concat(b.Errors))
+        : Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)>.Ok((a.Value.Item1, a.Value.Item2, a.Value.Item3, a.Value.Item4, a.Value.Item5, a.Value.Item6, a.Value.Item7, a.Value.Item8, a.Value.Item9, a.Value.Item10, a.Value.Item11, b.Value));
+    public static Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)> Or<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)> a, Result<T13> b) => !a.Success || !b.Success
+        ? Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)>.Error(a.Errors.Concat(b.Errors))
+        : Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)>.Ok((a.Value.Item1, a.Value.Item2, a.Value.Item3, a.Value.Item4, a.Value.Item5, a.Value.Item6, a.Value.Item7, a.Value.Item8, a.Value.Item9, a.Value.Item10, a.Value.Item11, a.Value.Item12, b.Value));
+    public static Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)> Or<T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)> a, Result<T14> b) => !a.Success || !b.Success
+        ? Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)>.Error(a.Errors.Concat(b.Errors))
+        : Result<(T, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)>.Ok((a.Value.Item1, a.Value.Item2, a.Value.Item3, a.Value.Item4, a.Value.Item5, a.Value.Item6, a.Value.Item7, a.Value.Item8, a.Value.Item9, a.Value.Item10, a.Value.Item11, a.Value.Item12, a.Value.Item13, b.Value));
 }


### PR DESCRIPTION
Allow index-usage in BindAll
Longer Or-tuples available
ErrorBase.Data can now be added to manually
Removed obsolete BindAll and BindEach-methods