### PR TITLE
Fix race conditions in MigrationRunner with SQL Server application locks

### DIFF
--- a/Sql/DotNetThoughts.Sql.Migrations.Tests/TestMigrationRunner.cs
+++ b/Sql/DotNetThoughts.Sql.Migrations.Tests/TestMigrationRunner.cs
@@ -1,4 +1,4 @@
-﻿using FakeItEasy;
+using FakeItEasy;
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -20,6 +20,26 @@ public class TestMigrationRunner : MigrationRunner<TestMigrationRunner>
 
     public TestMigrationRunner(Action<MigrationRunnerConfiguration<TestMigrationRunner>> configure)
         : base(DefaultConfiguration(configure), A.Fake<ILogger<TestMigrationRunner>>())
+    {
+    }
+}
+
+public class TestMigrationRunnerWithShortTimeout : MigrationRunner<TestMigrationRunnerWithShortTimeout>
+{
+    public static MigrationRunnerConfiguration<TestMigrationRunnerWithShortTimeout> DefaultConfiguration(Action<MigrationRunnerConfiguration<TestMigrationRunnerWithShortTimeout>> configure)
+    {
+        var configuration = new MigrationRunnerConfiguration<TestMigrationRunnerWithShortTimeout>(Options.Create(new MigrationRunnerOptions<TestMigrationRunnerWithShortTimeout>
+        {
+            AutoCreate = AutoCreateMode.NEVER, // Database already exists
+            EnableSnapshot = false,
+            MigrationLockTimeoutMs = 100 // Very short timeout for testing
+        }));
+        configure(configuration);
+        return configuration;
+    }
+
+    public TestMigrationRunnerWithShortTimeout(Action<MigrationRunnerConfiguration<TestMigrationRunnerWithShortTimeout>> configure)
+        : base(DefaultConfiguration(configure), A.Fake<ILogger<TestMigrationRunnerWithShortTimeout>>())
     {
     }
 }

--- a/Sql/DotNetThoughts.Sql.Migrations.Tests/TestMigrationRunner.cs
+++ b/Sql/DotNetThoughts.Sql.Migrations.Tests/TestMigrationRunner.cs
@@ -43,3 +43,48 @@ public class TestMigrationRunnerWithShortTimeout : MigrationRunner<TestMigration
     {
     }
 }
+
+/// <summary>
+/// Migration runner with IF_NOT_EXISTS mode - used for concurrent creation tests.
+/// </summary>
+public class TestMigrationRunnerIfNotExists : MigrationRunner<TestMigrationRunnerIfNotExists>
+{
+    public static MigrationRunnerConfiguration<TestMigrationRunnerIfNotExists> DefaultConfiguration(Action<MigrationRunnerConfiguration<TestMigrationRunnerIfNotExists>> configure)
+    {
+        var configuration = new MigrationRunnerConfiguration<TestMigrationRunnerIfNotExists>(Options.Create(new MigrationRunnerOptions<TestMigrationRunnerIfNotExists>
+        {
+            AutoCreate = AutoCreateMode.IF_NOT_EXISTS,
+            EnableSnapshot = false
+        }));
+        configure(configuration);
+        return configuration;
+    }
+
+    public TestMigrationRunnerIfNotExists(Action<MigrationRunnerConfiguration<TestMigrationRunnerIfNotExists>> configure)
+        : base(DefaultConfiguration(configure), A.Fake<ILogger<TestMigrationRunnerIfNotExists>>())
+    {
+    }
+}
+
+/// <summary>
+/// Migration runner with locking DISABLED - used to demonstrate race conditions.
+/// </summary>
+public class TestMigrationRunnerNoLocking : MigrationRunner<TestMigrationRunnerNoLocking>
+{
+    public static MigrationRunnerConfiguration<TestMigrationRunnerNoLocking> DefaultConfiguration(Action<MigrationRunnerConfiguration<TestMigrationRunnerNoLocking>> configure)
+    {
+        var configuration = new MigrationRunnerConfiguration<TestMigrationRunnerNoLocking>(Options.Create(new MigrationRunnerOptions<TestMigrationRunnerNoLocking>
+        {
+            AutoCreate = AutoCreateMode.NEVER, // DB pre-created in test
+            EnableSnapshot = false,
+            UseMigrationLock = false // LOCKING DISABLED - will cause race conditions!
+        }));
+        configure(configuration);
+        return configuration;
+    }
+
+    public TestMigrationRunnerNoLocking(Action<MigrationRunnerConfiguration<TestMigrationRunnerNoLocking>> configure)
+        : base(DefaultConfiguration(configure), A.Fake<ILogger<TestMigrationRunnerNoLocking>>())
+    {
+    }
+}

--- a/Sql/DotNetThoughts.Sql.Migrations.Tests/Tests.cs
+++ b/Sql/DotNetThoughts.Sql.Migrations.Tests/Tests.cs
@@ -1,4 +1,4 @@
-﻿using Bogus;
+using Bogus;
 
 using Dapper;
 
@@ -76,5 +76,167 @@ public class Tests
         var versionInfo = await connection.QueryAsync<VersionInfo>("SELECT * FROM dbo.VersionInfo");
         return Verify(Table.Render([.. versionInfo]));
 
+    }
+
+    /// <summary>
+    /// Tests that concurrent migrations serialize correctly using application locks.
+    /// Two runners should not cause PK_VersionInfo violations.
+    /// </summary>
+    [Test]
+    public async Task ConcurrentMigrationsSerialize(CancellationToken cancellationToken)
+    {
+        var masterConnectionString = _masterConnectionString ?? throw new Exception("Connectionstring not set");
+
+        var dbNameFaker = new Faker();
+        var dbName = dbNameFaker.Hacker.Adjective() + dbNameFaker.Hacker.Noun();
+
+        var connectionString = ConnectionStringUtils.ReplaceInitialCatalog(masterConnectionString, dbName);
+
+        var migrations = new List<FakeMigration>
+        {
+            new FakeMigration(1, "Migration 1", false) { ExecuteImpl = (c, t, timeout) => Thread.Sleep(100) },
+            new FakeMigration(2, "Migration 2", false) { ExecuteImpl = (c, t, timeout) => Thread.Sleep(100) },
+            new FakeMigration(3, "Migration 3", false) { ExecuteImpl = (c, t, timeout) => Thread.Sleep(100) },
+            new FakeMigration(4, "Migration 4", false) { ExecuteImpl = (c, t, timeout) => Thread.Sleep(100) },
+        };
+
+        // Create two runners that will run concurrently
+        var migrationLoader1 = new FakeMigrationLoader();
+        var migrationLoader2 = new FakeMigrationLoader();
+        foreach (var migration in migrations)
+        {
+            migrationLoader1.Add(migration);
+            migrationLoader2.Add(migration);
+        }
+
+        var runner1 = new TestMigrationRunner(x => x.AddMigrationLoaders(migrationLoader1));
+        var runner2 = new TestMigrationRunner(x => x.AddMigrationLoaders(migrationLoader2));
+
+        // Run both concurrently - with locking, both should complete without errors
+        var task1 = runner1.RunAsync(connectionString);
+        var task2 = runner2.RunAsync(connectionString);
+
+        await Task.WhenAll(task1, task2);
+
+        // Verify results - each version should appear exactly once
+        using var connection = new SqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        var versionInfo = await connection.QueryAsync<VersionInfo>("SELECT * FROM dbo.VersionInfo ORDER BY Version");
+        var versions = versionInfo.ToList();
+
+        await Assert.That(versions.Count).IsEqualTo(4);
+        await Assert.That(versions.Select(v => v.Version)).IsEquivalentTo([1L, 2L, 3L, 4L]);
+    }
+
+    /// <summary>
+    /// Tests that concurrent DROP_CREATE operations serialize correctly.
+    /// </summary>
+    [Test]
+    public async Task ConcurrentDropCreateSerializes(CancellationToken cancellationToken)
+    {
+        var masterConnectionString = _masterConnectionString ?? throw new Exception("Connectionstring not set");
+
+        var dbNameFaker = new Faker();
+        var dbName = dbNameFaker.Hacker.Adjective() + dbNameFaker.Hacker.Noun();
+
+        var connectionString = ConnectionStringUtils.ReplaceInitialCatalog(masterConnectionString, dbName);
+
+        var migrations = new List<FakeMigration>
+        {
+            new FakeMigration(1, "Migration 1", false),
+            new FakeMigration(2, "Migration 2", false),
+        };
+
+        var migrationLoader1 = new FakeMigrationLoader();
+        var migrationLoader2 = new FakeMigrationLoader();
+        foreach (var migration in migrations)
+        {
+            migrationLoader1.Add(migration);
+            migrationLoader2.Add(migration);
+        }
+
+        // Both use DROP_CREATE mode (default in TestMigrationRunner)
+        var runner1 = new TestMigrationRunner(x => x.AddMigrationLoaders(migrationLoader1));
+        var runner2 = new TestMigrationRunner(x => x.AddMigrationLoaders(migrationLoader2));
+
+        // Run both concurrently - with locking, one will complete first, then the other
+        // will drop and recreate, but without race conditions
+        var task1 = runner1.RunAsync(connectionString);
+        var task2 = runner2.RunAsync(connectionString);
+
+        await Task.WhenAll(task1, task2);
+
+        // Verify the database exists and is properly migrated
+        using var connection = new SqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        var versionInfo = await connection.QueryAsync<VersionInfo>("SELECT * FROM dbo.VersionInfo ORDER BY Version");
+        var versions = versionInfo.ToList();
+
+        await Assert.That(versions.Count).IsEqualTo(2);
+        await Assert.That(versions.Select(v => v.Version)).IsEquivalentTo([1L, 2L]);
+    }
+
+    /// <summary>
+    /// Tests that lock timeout throws MigrationLockException with helpful message.
+    /// </summary>
+    [Test]
+    public async Task LockTimeoutThrowsMigrationLockException(CancellationToken cancellationToken)
+    {
+        var masterConnectionString = _masterConnectionString ?? throw new Exception("Connectionstring not set");
+
+        var dbNameFaker = new Faker();
+        var dbName = dbNameFaker.Hacker.Adjective() + dbNameFaker.Hacker.Noun();
+
+        var connectionString = ConnectionStringUtils.ReplaceInitialCatalog(masterConnectionString, dbName);
+
+        // First, create the database so we can acquire a lock on it
+        using (var masterConn = new SqlConnection(masterConnectionString))
+        {
+            await masterConn.OpenAsync(cancellationToken);
+            await masterConn.ExecuteAsync($"CREATE DATABASE [{dbName}]");
+        }
+
+        // Open a connection and hold a lock
+        using var lockConnection = new SqlConnection(connectionString);
+        await lockConnection.OpenAsync(cancellationToken);
+
+        var lockResource = $"DotNetThoughts.Sql.Migrations:RunMigrations:{dbName}";
+        await lockConnection.ExecuteAsync(
+            "EXEC sp_getapplock @Resource = @LockResource, @LockMode = 'Exclusive', @LockOwner = 'Session', @LockTimeout = 60000",
+            new { LockResource = lockResource });
+
+        try
+        {
+            // Now try to run migrations with a very short timeout
+            var migrations = new List<FakeMigration>
+            {
+                new FakeMigration(1, "Migration 1", false),
+            };
+
+            var migrationLoader = new FakeMigrationLoader();
+            foreach (var migration in migrations)
+            {
+                migrationLoader.Add(migration);
+            }
+
+            var runner = new TestMigrationRunnerWithShortTimeout(x => x.AddMigrationLoaders(migrationLoader));
+
+            // This should throw MigrationLockException
+            var exception = await Assert.ThrowsAsync<MigrationLockException>(
+                async () => await runner.RunAsync(connectionString));
+
+            await Assert.That(exception).IsNotNull();
+            await Assert.That(exception!.DatabaseName).IsEqualTo(dbName);
+            await Assert.That(exception.LockResource).Contains("RunMigrations");
+            await Assert.That(exception.TimeoutMs).IsEqualTo(100);
+            await Assert.That(exception.Message).Contains("Failed to acquire migration lock");
+        }
+        finally
+        {
+            // Release the lock
+            await lockConnection.ExecuteAsync(
+                "EXEC sp_releaseapplock @Resource = @LockResource, @LockOwner = 'Session'",
+                new { LockResource = lockResource });
+        }
     }
 }

--- a/Sql/DotNetThoughts.Sql.Migrations/MigrationLockException.cs
+++ b/Sql/DotNetThoughts.Sql.Migrations/MigrationLockException.cs
@@ -1,0 +1,44 @@
+namespace DotNetThoughts.Sql.Migrations;
+
+/// <summary>
+/// Exception thrown when a migration lock cannot be acquired within the configured timeout.
+/// </summary>
+public class MigrationLockException : Exception
+{
+    public string DatabaseName { get; }
+    public string LockResource { get; }
+    public int TimeoutMs { get; }
+    public int ResultCode { get; }
+
+    public MigrationLockException(string databaseName, string lockResource, int timeoutMs, int resultCode)
+        : base(CreateMessage(databaseName, lockResource, timeoutMs, resultCode))
+    {
+        DatabaseName = databaseName;
+        LockResource = lockResource;
+        TimeoutMs = timeoutMs;
+        ResultCode = resultCode;
+    }
+
+    private static string CreateMessage(string databaseName, string lockResource, int timeoutMs, int resultCode)
+    {
+        var resultDescription = resultCode switch
+        {
+            -1 => "The lock request timed out.",
+            -2 => "The lock request was canceled.",
+            -3 => "The lock request was chosen as a deadlock victim.",
+            -999 => "Parameter validation or other call error.",
+            _ => $"Unknown error (result code: {resultCode})."
+        };
+
+        return $"""
+            Failed to acquire migration lock for database '{databaseName}'.
+            Lock resource: {lockResource}
+            Timeout: {timeoutMs}ms
+            Result: {resultDescription}
+            
+            This typically occurs when another migration process is running against the same database.
+            If you expect migrations to take longer than {timeoutMs}ms, consider increasing the 
+            MigrationLockTimeoutMs option in MigrationRunnerOptions.
+            """;
+    }
+}

--- a/Sql/DotNetThoughts.Sql.Migrations/MigrationRunnerOptions.cs
+++ b/Sql/DotNetThoughts.Sql.Migrations/MigrationRunnerOptions.cs
@@ -40,4 +40,18 @@ public class MigrationRunnerOptions<T> where T : MigrationRunner<T>
     /// </summary>
     public string? SourceDatabaseForRestore { get; set; } = null;
 
+    /// <summary>
+    /// When true, uses SQL Server application locks (sp_getapplock) to serialize concurrent migration runs.
+    /// This prevents race conditions when multiple processes attempt to run migrations simultaneously.
+    /// Default is true.
+    /// </summary>
+    public bool UseMigrationLock { get; set; } = true;
+
+    /// <summary>
+    /// The timeout in milliseconds for acquiring migration locks.
+    /// If the lock cannot be acquired within this time, the migration will fail.
+    /// Default is 60000ms (60 seconds).
+    /// </summary>
+    public int MigrationLockTimeoutMs { get; set; } = 60000;
+
 }


### PR DESCRIPTION
## Summary
- Adds SQL Server application locks (`sp_getapplock`) to serialize concurrent migration runs
- Prevents intermittent `PK_VersionInfo` violations when multiple processes run migrations simultaneously  
- Prevents TOCTOU races during `DROP_CREATE` database operations

## Problem

When multiple `MigrationRunner.RunAsync()` calls execute concurrently (e.g., in a scaled-out deployment or parallel test runs), two race conditions can occur:

### 1. Database create/drop TOCTOU race

```
Runner A: DatabaseExists() → false
Runner B: DatabaseExists() → false  
Runner A: CREATE DATABASE
Runner B: CREATE DATABASE → ERROR: Database already exists
```

Or with `DROP_CREATE`:
```
Runner A: DROP DATABASE
Runner B: DROP DATABASE → ERROR: Cannot drop, does not exist
```

### 2. Migration execution race

```
Runner A: GetCurrentVersion() → 0
Runner B: GetCurrentVersion() → 0
Runner A: INSERT VersionInfo (Version=1)
Runner B: INSERT VersionInfo (Version=1) → PK_VersionInfo violation!
```

## Solution

Uses two SQL Server application locks (`sp_getapplock`) with database-name scoping:

- **Lock A (master-scoped):** Protects `CREATE DATABASE` / `DROP DATABASE` operations
  - Resource: `DotNetThoughts.Sql.Migrations:CreateDatabase:{databaseName}`
  
- **Lock B (database-scoped):** Protects `GetCurrentVersion` + migration selection + applying migrations
  - Resource: `DotNetThoughts.Sql.Migrations:RunMigrations:{databaseName}`

### Why `sp_getapplock`?
- Works across processes/threads/machines
- No schema changes required
- Session-owned locks release automatically on connection close
- Standard pattern for migration runners

## New Options

```csharp
public class MigrationRunnerOptions<T>
{
    // When true, uses application locks to serialize concurrent runs (default: true)
    public bool UseMigrationLock { get; set; } = true;
    
    // Lock acquisition timeout in milliseconds (default: 60000 = 60 seconds)
    public int MigrationLockTimeoutMs { get; set; } = 60000;
}
```

## Breaking Changes

None. Locking is enabled by default but can be disabled via `UseMigrationLock = false`.

## Tests Added

- `ConcurrentMigrationsSerialize` - Two runners against same DB complete without PK violations
- `ConcurrentDropCreateSerializes` - Two concurrent DROP_CREATE runs complete without errors
- `LockTimeoutThrowsMigrationLockException` - Verifies timeout throws with helpful message